### PR TITLE
New Joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pub struct Employees {
 ## Building queries
 All queries start from a `GenericRepository` tied to an entity. Chaining methods configures the SQL without executing it until an async terminal call:
 ```rust
-use rquery_orm::{col, on, condition, val, GenericRepository, JoinType, QueryExecutor};
+use rquery_orm::{col, on, condition, GenericRepository, JoinType, QueryExecutor};
 
 let repo = GenericRepository::<Employees>::new(db);
 let rows = repo
@@ -90,7 +90,7 @@ let rows = repo
 ```
 - Column = column (typed):
 ```rust
-use rquery_orm::{on, condition};
+use rquery_orm::{on, condition, JoinType};
 let rows = repo
     .Select()
     .Join(JoinType::Left, on!(Employees::country_id == Countries::country_id))

--- a/README.md
+++ b/README.md
@@ -41,15 +41,69 @@ pub struct Employees {
 ## Building queries
 All queries start from a `GenericRepository` tied to an entity. Chaining methods configures the SQL without executing it until an async terminal call:
 ```rust
-use rquery_orm::{col, val, GenericRepository, JoinType, QueryExecutor};
+use rquery_orm::{col, on, condition, val, GenericRepository, JoinType, QueryExecutor};
 
 let repo = GenericRepository::<Employees>::new(db);
 let rows = repo
     .Select()
-    .Join(JoinType::Left, "Countries C", col!("Employees.CountryId").eq(col!("C.CountryId")))
-    .Where(col!("Employees.CountryId").eq(val!("Mex")))
+    .Join(JoinType::Left, on!(Employees::country_id == Countries::country_id))
+    .Where(condition!(Employees::country_id == "Mex"))
     .OrderBy("Employees.HireDate DESC")
     .Top(10)
+    .to_list_async()
+    .await?;
+```
+
+## Join
+- Typed (recommended): uses compile-time entity and field names.
+```rust
+use rquery_orm::{on, JoinType};
+let rows = repo
+    .Select()
+    .Join(JoinType::Left, on!(Employees::country_id == Countries::country_id))
+    .to_list_async()
+    .await?;
+```
+- String-based (aliasing): handy for complex/manual joins or aliases.
+```rust
+use rquery_orm::{col, JoinType};
+let rows = repo
+    .Select()
+    .Join(
+        JoinType::Left,
+        "Countries C",
+        col!("Employees.CountryId").eq(col!("C.CountryId")),
+    )
+    .to_list_async()
+    .await?;
+```
+
+## Where
+- Column = value (typed):
+```rust
+use rquery_orm::condition;
+let rows = repo
+    .Select()
+    .Where(condition!(Employees::country_id == "Mex"))
+    .to_list_async()
+    .await?;
+```
+- Column = column (typed):
+```rust
+use rquery_orm::{on, condition};
+let rows = repo
+    .Select()
+    .Join(JoinType::Left, on!(Employees::country_id == Countries::country_id))
+    .Where(condition!(Employees::country_id == Countries::country_id))
+    .to_list_async()
+    .await?;
+```
+- With aliases or ad-hoc paths (string literal):
+```rust
+use rquery_orm::condition;
+let rows = repo
+    .Select()
+    .Where(condition!("E.CountryId" == "Mex"))
     .to_list_async()
     .await?;
 ```
@@ -95,6 +149,17 @@ if let Err(errors) = user.validate() {
 ```
 
 When using repository methods like `insert_async` or `update_async`, validation runs automatically; failed validation aborts the operation.
+
+### Dual repository + typed join
+```rust
+use rquery_orm::{on, GenericRepository, JoinType};
+let pairs: Vec<(Employees, Countries)> = GenericRepository::<(Employees, Countries)>::new(db)
+    .Select()
+    .Join(JoinType::Left, on!(Employees::country_id == Countries::country_id))
+    .Top(10)
+    .to_list_async()
+    .await?;
+```
 
 ---
 See `examples/usage.rs` and the tests folder for additional scenarios.

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDateTime;
-use rquery_orm::{col, connect_postgres, on, condition, val, Entity, GenericRepository, JoinType, QueryExecutor};
+use rquery_orm::{col, connect_postgres, on, condition, Entity, GenericRepository, JoinType, QueryExecutor};
 
 mod employees_mod {
     use super::*;

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -1,39 +1,76 @@
 use chrono::NaiveDateTime;
-use rquery_orm::{col, connect_postgres, val, Entity, GenericRepository, JoinType, QueryExecutor};
+use rquery_orm::{col, connect_postgres, on, condition, val, Entity, GenericRepository, JoinType, QueryExecutor};
 
-#[derive(Entity, Debug, Clone)]
-#[table(name = "Employees")]
-pub struct Employees {
-    #[key(is_identity = true)]
-    pub employee_id: i32,
-    #[column]
-    pub first_name: String,
-    #[column]
-    pub last_name: String,
-    #[column]
-    pub age: i32,
-    #[column]
-    pub hire_date: NaiveDateTime,
+mod employees_mod {
+    use super::*;
+    #[derive(Entity, Debug, Clone)]
+    #[table(name = "Employees")]
+    pub struct Employees {
+        #[key(is_identity = true)]
+        pub employee_id: i32,
+        #[column]
+        pub first_name: String,
+        #[column]
+        pub last_name: String,
+        #[column]
+        pub age: i32,
+        #[column]
+        pub country_id: String,
+        #[column]
+        pub hire_date: NaiveDateTime,
+    }
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+mod countries_mod {
+    use super::*;
+    #[derive(Entity, Debug, Clone)]
+    #[table(name = "Countries")]
+    pub struct Countries {
+        #[key(is_identity = true)]
+        pub country_id: String,
+        #[column]
+        pub name: String,
+    }
+}
+
+async fn example_simple() -> anyhow::Result<()> {
+    use employees_mod::Employees;
     let db = connect_postgres("localhost", 5432, "mydb", "postgres", "secret").await?;
     let employees = GenericRepository::<Employees>::new(db);
-
-    let list = employees
+    let _rows = employees
         .Select()
         .Join(
             JoinType::Left,
             "Countries C",
             col!("Employees.CountryId").eq(col!("C.CountryId")),
         )
-        .Where(col!("Employees.CountryId").eq(val!("Mex")))
+        .Where(condition!(Employees::country_id == "Mex"))
         .OrderBy("Employees.HireDate DESC")
         .Top(10)
         .to_list_async()
         .await?;
+    Ok(())
+}
 
-    println!("rows: {}", list.len());
+async fn example_dual() -> anyhow::Result<()> {
+    use countries_mod::Countries;
+    use employees_mod::Employees;
+    let db = connect_postgres("localhost", 5432, "mydb", "postgres", "secret").await?;
+    let repo = GenericRepository::<(Employees, Countries)>::new(db);
+    let _pairs = repo
+        .Select()
+        .Join(JoinType::Left, on!(Employees::country_id == Countries::country_id))
+        .Where(condition!(Countries::name == "Mexico"))
+        .Top(10)
+        .to_list_async()
+        .await?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Only call functions; these connect to DB but won't run under `cargo test --no-run`.
+    let _ = example_simple().await;
+    let _ = example_dual().await;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@ pub mod services;
 pub use db::{connect_mssql, connect_postgres, DatabaseRef, DbKind};
 pub use infrastructure::generic_repository::GenericRepository;
 pub use mapping::{
-    ColumnMeta, Entity, FromRowNamed, KeyAsGuid, KeyAsInt, KeyAsString, KeyMeta, Persistable,
-    RelationMeta, TableMeta, Validatable,
+    ColumnMeta, Entity, FromRowNamed, FromRowWithPrefix, KeyAsGuid, KeyAsInt, KeyAsString,
+    KeyMeta, Persistable, RelationMeta, TableMeta, Validatable,
 };
-pub use query::{Expr, JoinType, PlaceholderStyle, Query, SqlParam, ToParam};
+pub use query::{DualQuery, Expr, JoinType, PlaceholderStyle, Query, SqlParam, ToParam};
 pub use repository::{Crud, QueryExecutor, Repository};
 
 pub use rquery_orm_macros::Entity; // derive macro

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -53,6 +53,13 @@ pub trait FromRowNamed: Sized {
     fn from_row_pg(row: &tokio_postgres::Row) -> anyhow::Result<Self>;
 }
 
+// Like FromRowNamed, but expects column names to be prefixed with
+// a short identifier, e.g., "t_ColumnName" or "u_ColumnName".
+pub trait FromRowWithPrefix: Sized {
+    fn from_row_ms_with(row: &tiberius::Row, prefix: &str) -> anyhow::Result<Self>;
+    fn from_row_pg_with(row: &tokio_postgres::Row, prefix: &str) -> anyhow::Result<Self>;
+}
+
 pub trait Validatable {
     fn validate(&self) -> Result<(), Vec<String>>;
 }

--- a/tests/it_mssql.rs
+++ b/tests/it_mssql.rs
@@ -33,7 +33,7 @@ async fn it_mssql_select() -> anyhow::Result<()> {
             "Countries C",
             col!("Employees.CountryId").eq(col!("C.CountryId")),
         )
-        .Where(col!("Employees.CountryId").eq(val!("Mex")))
+        .Where(condition!(Employees::country_id == "Mex"))
         .OrderBy("Employees.HireDate DESC")
         .Top(10)
         .to_list_async()
@@ -61,7 +61,7 @@ async fn it_mssql_insert() -> anyhow::Result<()> {
 
     let inserted = repo
         .Select()
-        .Where(col!("Employees.EmployeeId").eq(val!(2)))
+        .Where(condition!(Employees::employee_id == 2))
         .to_single_async()
         .await?
         .unwrap();
@@ -95,7 +95,7 @@ async fn it_mssql_update() -> anyhow::Result<()> {
 
     let updated = repo
         .Select()
-        .Where(col!("Employees.EmployeeId").eq(val!(3)))
+        .Where(condition!(Employees::employee_id == 3))
         .to_single_async()
         .await?
         .unwrap();
@@ -124,7 +124,7 @@ async fn it_mssql_delete() -> anyhow::Result<()> {
     repo.delete_by_key_async(SqlParam::I32(4)).await?;
     let none = repo
         .Select()
-        .Where(col!("Employees.EmployeeId").eq(val!(4)))
+        .Where(condition!(Employees::employee_id == 4))
         .to_list_async()
         .await?;
     assert_eq!(none.len(), 0);

--- a/tests/it_mssql.rs
+++ b/tests/it_mssql.rs
@@ -1,6 +1,7 @@
 use chrono::NaiveDate;
 use rquery_orm::{
-    col, connect_mssql, val, Crud, Entity, GenericRepository, JoinType, QueryExecutor, SqlParam,
+    col, condition, connect_mssql, Crud, Entity, GenericRepository, JoinType, QueryExecutor,
+    SqlParam,
 };
 
 #[derive(Entity, Debug)]
@@ -33,7 +34,7 @@ async fn it_mssql_select() -> anyhow::Result<()> {
             "Countries C",
             col!("Employees.CountryId").eq(col!("C.CountryId")),
         )
-        .Where(condition!(Employees::country_id == "Mex"))
+        .Where(condition!(Employee::country_id == "Mex"))
         .OrderBy("Employees.HireDate DESC")
         .Top(10)
         .to_list_async()
@@ -61,7 +62,7 @@ async fn it_mssql_insert() -> anyhow::Result<()> {
 
     let inserted = repo
         .Select()
-        .Where(condition!(Employees::employee_id == 2))
+        .Where(condition!(Employee::employee_id == 2))
         .to_single_async()
         .await?
         .unwrap();
@@ -95,7 +96,7 @@ async fn it_mssql_update() -> anyhow::Result<()> {
 
     let updated = repo
         .Select()
-        .Where(condition!(Employees::employee_id == 3))
+        .Where(condition!(Employee::employee_id == 3))
         .to_single_async()
         .await?
         .unwrap();
@@ -124,7 +125,7 @@ async fn it_mssql_delete() -> anyhow::Result<()> {
     repo.delete_by_key_async(SqlParam::I32(4)).await?;
     let none = repo
         .Select()
-        .Where(condition!(Employees::employee_id == 4))
+        .Where(condition!(Employee::employee_id == 4))
         .to_list_async()
         .await?;
     assert_eq!(none.len(), 0);

--- a/tests/it_pg.rs
+++ b/tests/it_pg.rs
@@ -42,7 +42,7 @@ async fn it_pg_select_chain() -> anyhow::Result<()> {
             "Countries C",
             col!("Employees.CountryId").eq(col!("C.CountryId")),
         )
-        .Where(col!("Employees.CountryId").eq(val!("Mex")))
+        .Where(condition!(Employees::country_id == "Mex"))
         .OrderBy("Employees.HireDate DESC")
         .Top(1)
         .to_list_async()

--- a/tests/it_pg.rs
+++ b/tests/it_pg.rs
@@ -1,5 +1,6 @@
 use rquery_orm::{
-    col, connect_postgres, val, DatabaseRef, Entity, GenericRepository, JoinType, QueryExecutor,
+    col, condition, connect_postgres, DatabaseRef, Entity, GenericRepository, JoinType,
+    QueryExecutor,
 };
 
 #[derive(Entity, Debug)]
@@ -42,7 +43,7 @@ async fn it_pg_select_chain() -> anyhow::Result<()> {
             "Countries C",
             col!("Employees.CountryId").eq(col!("C.CountryId")),
         )
-        .Where(condition!(Employees::country_id == "Mex"))
+        .Where(condition!(Employee::country_id == "Mex"))
         .OrderBy("Employees.HireDate DESC")
         .Top(1)
         .to_list_async()

--- a/tests/unit_query.rs
+++ b/tests/unit_query.rs
@@ -1,6 +1,6 @@
 use rquery_orm::{
-    col, val, Entity, FromRowNamed, FromRowWithPrefix, JoinType, Persistable, PlaceholderStyle,
-    Query, SqlParam, TableMeta, Validatable,
+    col, condition, val, Entity, FromRowNamed, FromRowWithPrefix, JoinType, Persistable,
+    PlaceholderStyle, Query, SqlParam, TableMeta, Validatable,
 };
 
 struct Dummy;


### PR DESCRIPTION
This pull request introduces significant enhancements to the ergonomics and type safety of join and filter operations in the ORM, as well as improvements to entity macro code generation and dual-entity query support. The main changes include new macros for typed joins and conditions, expanded trait support for extracting entities from query results (including dual-entity queries), and updates to documentation and examples to reflect these new idioms.

Key changes by theme:

**Typed Joins and Conditions (Macros and API):**
- Added new `on!` and `condition!` macros for building typed join and filter expressions, enabling compile-time checked field and table names instead of string-based SQL fragments. This improves safety and developer experience.
- Updated documentation (`README.md`) and usage examples (`examples/usage.rs`) to demonstrate and recommend the new macros for joins and conditions, including dual-entity queries. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R110) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R153-R163) [[3]](diffhunk://#diff-640ae2adc4320ba898f68a27c2853a3c3444c4253c9babcec39719441039593bL2-R5) [[4]](diffhunk://#diff-640ae2adc4320ba898f68a27c2853a3c3444c4253c9babcec39719441039593bR18-R74)

**Dual-entity Query Support:**
- Implemented `GenericRepository<(T, U)>` and a new `DualQuery` type, allowing for type-safe queries that return tuples of two entities (e.g., for joined results). [[1]](diffhunk://#diff-1fc1072bef772be65cdf3c5eae95f765d07086b2d7ea69e3407a715adbc2bb5eR59-R72) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L11-R14)
- Added trait `FromRowWithPrefix` and corresponding macro codegen, enabling extraction of entities from rows with column name prefixes (used in dual-entity queries to avoid column name collisions). [[1]](diffhunk://#diff-4a565ad4fa4c22fd4d27d131e51b8f208d38dfbb5795cbf9d6e142ebff97695aR56-R62) [[2]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48R512-R520)

**Entity Macro Improvements:**
- The entity derive macro now generates associated constants for table and column names, and implements `FromRowWithPrefix` for each entity. This enables the new typed macros and dual-entity extraction. [[1]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48R40-R42) [[2]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48R141) [[3]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48R245-R247) [[4]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48L253-R260) [[5]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48R309-R331) [[6]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48R475-R480) [[7]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48L470-R490) [[8]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48R512-R520) [[9]](diffhunk://#diff-a23bc7b5b8a1443ec608cc70cde6e7b6834aad5e73e3d16b527ab33a1e696c48R573-R577)

**API Cleanup and Ergonomics:**
- Simplified trait bounds and generics for `GenericRepository` and its implementations, making the API easier to use and understand. [[1]](diffhunk://#diff-1fc1072bef772be65cdf3c5eae95f765d07086b2d7ea69e3407a715adbc2bb5eL8-R17) [[2]](diffhunk://#diff-1fc1072bef772be65cdf3c5eae95f765d07086b2d7ea69e3407a715adbc2bb5eL32-R26)

These changes together provide a safer, more ergonomic, and more powerful way to express complex queries in a type-safe Rust ORM.