### PR TITLE
Specify macro crate version for crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ native-tls = "0.2"
 postgres-native-tls = "0.5"
 
 # Procedural macros para #[derive(Entity)]
-rquery-orm-macros = { path = "./rquery-orm-macros" }
+rquery-orm-macros = { version = "0.1.0", path = "./rquery-orm-macros" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
## Summary
- include explicit version for `rquery-orm-macros` path dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bed5773544832091ada6f17e1d2b6c